### PR TITLE
Add encrypted password to GitHub pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,7 @@ jobs:
           path: .cache
       - run: pip install mkdocs-material
       - run: pip install pillow cairosvg
+      - run: pip install mkdocs-encryptcontent-plugin
       - run: mkdocs gh-deploy --force
+        env: 
+          MKDOCS_PASSWORD: ${{ secrets.MKDOCS_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # rsna-documentation
-View documentation at (public): https://anw1998.github.io/rsna-documentation/
+View documentation at : https://anw1998.github.io/rsna-documentation/
+* Ask one of your colleagues for the password!
+* To avoid having to enter the password at every page, press `Ctrl` + `Enter` instead of `Enter` as you confirm the password input.
 
 I followed this tutorial: https://www.youtube.com/watch?v=Q-YA_dA8C20&t=292s
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,3 +60,12 @@ markdown_extensions:
 
 copyright: |
   &copy; 2023 <a href="https://github.com/anw1998"  target="_blank" rel="noopener">An Ni Wu</a>
+plugins:
+    - encryptcontent:
+        title_prefix: ''
+        summary: 'Please enter your password to access this website.'
+        placeholder: 'Enter password here'
+        encryption_info_message: ''
+        use_secret: 'MKDOCS_PASSWORD'
+        remember_password: True
+        default_expire_delay: 1


### PR DESCRIPTION
Avant de merger, il faudra ajouter un mot de passe dans les secrets du repository. 

Nom du secret : MKDOCS_PASSWORD 
[(documentation)](https://docs.github.com/en/actions/security-guides/encrypted-secrets)

