### PR TITLE
Restructure wiki: fix broken build, split resources, add onboarding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
-name: ci 
+name: ci
 on:
   push:
     branches:
-      - master 
+      - master
       - main
 permissions:
   contents: write
@@ -10,17 +10,17 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for git-revision-date-localized
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           key: ${{ github.ref }}
           path: .cache
-      - run: pip install mkdocs-material
-      - run: pip install pillow cairosvg
-      - run: pip install mkdocs-encryptcontent-plugin
+      - run: pip install -r requirements.txt
       - run: mkdocs gh-deploy --force
-        env: 
+        env:
           MKDOCS_PASSWORD: ${{ secrets.MKDOCS_PASSWORD }}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,27 +1,22 @@
-# Homepage
+# Létourneau-Guillon Lab
 
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+Welcome to the internal wiki of the Létourneau-Guillon research lab at the CRCHUM, Université de Montréal.
 
-## Commands
+Our work focuses on **neuroradiology AI** and **medical image segmentation**, with a particular interest in intracranial hemorrhage and stroke imaging.
 
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
+---
 
-## Project layout
+## Quick links
 
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+| | |
+|---|---|
+| :material-account-group: [Team](team.md) | Meet the lab members |
+| :material-flask: [Research](research.md) | Ongoing projects and publications |
+| :material-book-open-variant: [Resources](resources/index.md) | Learning resources by topic |
+| :material-clipboard-check: [Onboarding](onboarding.md) | Getting started at the CRCHUM |
+| :material-email: [Contact](contact.md) | How to reach us |
 
+---
 
-### Code for a specific language
-
-Some more code with the `py` at the start:
-
-``` py
-import pandas as pd
-```
-
+!!! tip "New to the lab?"
+    Start with the [Onboarding](onboarding.md) page, then explore [Resources](resources/index.md).

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,68 @@
+# Onboarding
+
+Bienvenue dans le laboratoire du Dr Laurent Létourneau-Guillon au CRCHUM.
+Cette page regroupe les informations essentielles pour bien démarrer votre stage ou projet de recherche.
+
+*Page inspirée du laboratoire [NeuroPoly](https://neuro.polymtl.ca/).*
+
+---
+
+## Arrivée au CRCHUM
+
+1. **Formulaires d'inscription et contrat** — Compléter avec le CRCHUM.
+   Personne ressource : melissa.nyembo.chum@ssss.gouv.qc.ca
+
+2. **Carte d'accès** — Après avoir rempli le formulaire d'inscription, se présenter à la sécurité au 1er étage (apporter une pièce d'identité).
+
+3. **Accès informatique** — Compte `pXXXXXX` et jeton VPN pour l'accès à distance.
+   Contact : simon.lessard.chum@ssss.gouv.qc.ca
+
+---
+
+## Formations éthiques obligatoires
+
+!!! warning "Exigence réglementaire"
+    Ces formations sont obligatoires au CRCHUM. Vous devez obtenir votre code `pXXXXXX` avant de pouvoir accéder aux modules en ligne (sauf le module CITI).
+
+- Consulter le document listant les formations à compléter (demander à votre superviseur).
+- Conserver une copie d'attestation pour chaque formation et la déposer dans votre dossier étudiant.
+
+---
+
+## Google Drive — Projets
+
+!!! danger "Données confidentielles"
+    Aucune information ou donnée confidentielle ne doit être déposée sur ce disque.
+
+[Accès au Google Drive partagé](https://drive.google.com) *(lien à mettre à jour)*
+
+### Pourquoi Google Drive vs OneDrive/Microsoft ?
+
+| Avantage | Détail |
+|---|---|
+| Google Docs en ligne | Plus rapide que l'équivalent Microsoft en ligne |
+| Intégration Zotero | Compatible avec Google Docs (non disponible dans Word Online) |
+| Google Colab | Pratique pour les notebooks partagés |
+
+**Désavantage :** Idéalement les données devraient être sur le serveur UdeM — migration possible vers OneDrive.
+
+**Alternative pour manuscrits :** [Overleaf](https://www.overleaf.com) (LaTeX avec gestion des références)
+
+### Types de contenu autorisés
+
+- Résultats d'analyses désidentifiés (tableaux, figures finales)
+- Manuscrits (rédigés dans Google Docs avec l'extension Zotero)
+- Données de jeux de données publiques *(accès ne peut pas être mis sur "everyone")*
+- Code synchronisé depuis GitHub
+
+---
+
+## Ressources recherche & programmation
+
+| Ressource | Description |
+|---|---|
+| [Version Control with Git (Software Carpentry)](https://swcarpentry.github.io/git-novice/) | Introduction pratique à Git |
+| [Deep Learning for Medical Imaging — Peter Chang](https://github.com/peterchang77/dl_tutor/tree/master/cs190) | Excellente introduction (Keras/TF2) |
+| [R for Data Science](https://r4ds.had.co.nz/) | Référence pour l'analyse statistique en R |
+
+Voir aussi la section [Ressources](resources/index.md) pour plus de liens par thématique.

--- a/docs/resources/hpc.md
+++ b/docs/resources/hpc.md
@@ -1,0 +1,19 @@
+# HPC (Compute Canada / CCDB)
+
+## Official Alliance Canada Wiki
+
+- [Using SSH keys in Linux](https://docs.alliancecan.ca/wiki/Using_SSH_keys_in_Linux)
+- [Installing your SSH Key](https://docs.alliancecan.ca/wiki/SSH_Keys#Using_CCDB)
+- [Connect to a Remote Server via SSH](https://docs.alliancecan.ca/wiki/SSH)
+- [Python — Creating and Using a Virtual Environment](https://docs.alliancecan.ca/wiki/Python#Creating_and_using_a_virtual_environment)
+- [Installing JupyterLab](https://docs.alliancecan.ca/wiki/Advanced_Jupyter_configuration)
+
+## Video Tutorials
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/K8wuaIKW6aU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+## Written Tutorials
+
+- [Compute Canada Video Tutorial GitHub (tvhahn)](https://github.com/tvhahn/compute-canada-hpc)
+- [Compute Canada Summarized Tutorial (pashazgit)](https://github.com/pashazgit/ComputeCanada-Wiki)
+- [IFT6759 — Cluster HPC Slides](https://alexhernandezgarcia.github.io/teaching/mlprojects23/slides/20230120-cluster#15)

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -1,0 +1,10 @@
+# Resources
+
+Learning resources for lab members, organized by topic.
+
+| Section | Description |
+|---|---|
+| [Neuroradiology](neuroradiology.md) | Radiology anatomy and case resources |
+| [Python & Deep Learning](python-dl.md) | Programming and ML tutorials |
+| [3D Slicer](slicer.md) | Segmentation tools and lab extensions |
+| [HPC (Compute Canada)](hpc.md) | Cluster setup, SSH, and job submission |

--- a/docs/resources/neuroradiology.md
+++ b/docs/resources/neuroradiology.md
@@ -1,0 +1,16 @@
+# Neuroradiology
+
+## Anatomy & Cases
+
+[Normal Head CT Anatomy](https://radiopaedia.org/cases/ct-head-axial-labelling-questions) — Radiopaedia axial labelling questions
+
+[Radiology Assistant — Hemorrhage](https://radiologyassistant.nl/neuroradiology/hemorrhage) — Neuroradiology hemorrhage module
+
+## University Resources
+
+[Queen's Undergraduate Online Radiology Resources](https://radiology.queensu.ca/academics/lectures)
+
+- [Queen's Neuroradiology Module](https://healthsci.queensu.ca/sites/elentra/medicine/storyline/Neuroradiology/story_html5.html)
+- [Queen's Neuro Imaging Module Part 3](https://radiology.queensu.ca/source/Radiology/neuro_module_part_3.pdf)
+
+[UBC Radiology](http://undergrad.ubcradiology.ca) — ANATOMY > NEURO > Brain Imaging & Brain Imaging Quiz

--- a/docs/resources/python-dl.md
+++ b/docs/resources/python-dl.md
@@ -1,0 +1,21 @@
+# Python & Deep Learning
+
+## Python
+
+[CS50's Introduction to Programming with Python](https://cs50.harvard.edu/python/2022/)
+
+[Automate the Boring Stuff with Python](https://www.udemy.com/course/automate/)
+
+## Deep Learning for Medical Imaging
+
+[CS 190 - Deep Learning for Medical Imaging (Peter Chang)](https://github.com/peterchang77/dl_tutor/tree/master/cs190)
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/V_xro1bcAuA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/M3ZWfamWrBM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+## Version Control
+
+[Getting Started with GitHub Desktop](https://docs.github.com/en/desktop/installing-and-configuring-github-desktop/overview/getting-started-with-github-desktop)
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/RGOj5yH7evk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/docs/resources/slicer.md
+++ b/docs/resources/slicer.md
@@ -1,0 +1,11 @@
+# 3D Slicer
+
+## Tutorials
+
+[3D Slicer Tutorial Playlist](https://www.youtube.com/playlist?list=PLeaIM0zUlEqswa6Pskg9uMq15LiWWYP39)
+
+## Lab Extensions
+
+[ICH_SEGMENTER_V2](https://github.com/laurentletg/ICH_SEGMENTER_V2) — Segmentation extension for ICH, IVH, and PHE. Includes a [tutorial on Google Drive](https://drive.google.com/drive/folders/1GQJi9Qqy5FyzHR690quK81nSt4WMXBbd).
+
+[Segment_Quality_Control](https://github.com/anw1998/Segment_Quality_Control) — Tool for verifying and correcting segment/label mapping. Run this after all annotations in a directory are complete.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,45 +1,65 @@
-site_name: RSNA Documentation
+site_name: Létourneau-Guillon Lab
+site_description: Internal wiki for the Létourneau-Guillon research lab — neuroradiology AI & medical imaging.
+site_author: Létourneau-Guillon Lab
+site_url: https://anw1998.github.io/rsna-documentation/
+
+repo_name: rsna-documentation
+repo_url: https://github.com/anw1998/rsna-documentation
+
 theme:
   name: material
   features:
     - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.sections
-    - toc.integrate
+    - navigation.indexes
+    - navigation.instant
+    - navigation.instant.prefetch
     - navigation.top
+    - navigation.footer
+    - navigation.path
+    - toc.integrate
     - search.suggest
     - search.highlight
+    - search.share
     - content.tabs.link
     - content.code.annotation
     - content.code.copy
+    - content.tooltips
   language: en
   palette:
     - scheme: default
       toggle:
-        icon: material/toggle-switch-off-outline 
+        icon: material/toggle-switch-off-outline
         name: Switch to dark mode
       primary: teal
-      accent: purple 
-    - scheme: slate 
+      accent: purple
+    - scheme: slate
       toggle:
         icon: material/toggle-switch
-        name: Switch to light mode    
+        name: Switch to light mode
       primary: teal
       accent: lime
 
 extra:
   social:
     - icon: fontawesome/brands/github-alt
-      link: https://github.com/anw1998
-    - icon: fontawesome/brands/twitter
-      link: https://twitter.com/
-    - icon: fontawesome/brands/linkedin
-      link: https://www.linkedin.com/in/
+      link: https://github.com/laurentletg
+      name: Lab GitHub
+
 nav:
-    - 'index.md'
-    - 'research.md'
-    - 'team.md'
-    - 'resources.md'
-    - 'contact.md'
+  - Home: index.md
+  - Research: research.md
+  - Team: team.md
+  - Resources:
+      - resources/index.md
+      - Neuroradiology: resources/neuroradiology.md
+      - Python & Deep Learning: resources/python-dl.md
+      - 3D Slicer: resources/slicer.md
+      - HPC (Compute Canada): resources/hpc.md
+  - Onboarding: onboarding.md
+  - Contact: contact.md
+
 markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
@@ -52,20 +72,29 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.mark
+  - pymdownx.tabbed:
+      alternate_style: true
   - attr_list
   - md_in_html
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+plugins:
+  - search
+  - glightbox
+  - git-revision-date-localized:
+      enable_creation_date: true
+      type: date
+  - tags
+  - encryptcontent:
+      title_prefix: ''
+      summary: 'Please enter your password to access this wiki.'
+      placeholder: 'Enter password here'
+      encryption_info_message: ''
+      use_secret: 'MKDOCS_PASSWORD'
+      remember_password: true
+      default_expire_delay: 24
 
 copyright: |
-  &copy; 2023 <a href="https://github.com/anw1998"  target="_blank" rel="noopener">An Ni Wu</a>
-plugins:
-    - encryptcontent:
-        title_prefix: ''
-        summary: 'Please enter your password to access this website.'
-        placeholder: 'Enter password here'
-        encryption_info_message: ''
-        use_secret: 'MKDOCS_PASSWORD'
-        remember_password: True
-        default_expire_delay: 1
+  &copy; 2025 Létourneau-Guillon Lab

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+mkdocs-material
+mkdocs-encryptcontent-plugin
+mkdocs-glightbox
+mkdocs-git-revision-date-localized-plugin
+pillow
+cairosvg


### PR DESCRIPTION
## Summary
- Fixes broken build: materialx.emoji → material.extensions.emoji
- Modernizes CI: checkout@v4, setup-python@v5, cache@v4; adds requirements.txt
- Splits monolithic resources.md into per-topic pages (neuroradiology, python-dl, slicer, hpc)
- Adds onboarding.md from PDF content (CRCHUM arrival, ethics, Drive policy)
- New homepage with lab description and quick-link table
- Adds glightbox, git-revision-date-localized, tags plugins; enables navigation.instant/path/indexes

## Test plan
- [ ] Run `mkdocs serve` locally — no build errors
- [ ] Verify resource sub-pages render correctly
- [ ] Confirm CI deploys to GitHub Pages after merge
- [ ] Fill in placeholder content (team photos, social links, contact) in follow-up