### PR TITLE
Restructure wiki: fix broken build, split resources, add onboarding

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,9 +92,10 @@ plugins:
       summary: 'Please enter your password to access this wiki.'
       placeholder: 'Enter password here'
       encryption_info_message: ''
-      use_secret: 'MKDOCS_PASSWORD'
+      password_inventory:
+        staff:
+          - !ENV MKDOCS_PASSWORD
       remember_password: true
-      default_expire_delay: 24
 
 copyright: |
   &copy; 2025 Létourneau-Guillon Lab


### PR DESCRIPTION
Replace removed use_secret and default_expire_delay with the new password_inventory + !ENV syntax required by the current plugin version.